### PR TITLE
Fix handling of malformed twitter link

### DIFF
--- a/lib/handler/url_check.go
+++ b/lib/handler/url_check.go
@@ -93,6 +93,7 @@ func parseMsg(guild *config.Guild, origin string) []string {
 		case "twitter.com", "m.twitter.com", "mobile.twitter.com", "fxtwitter.com", "vxtwitter.com", "x.com":
 			Url.Host = "twitter.com"
 			Url.RawQuery = ""
+			Url.ForceQuery = false
 		}
 		if net.ParseIP(Url.Host) != nil {
 			continue


### PR DESCRIPTION
ignore suffix `?`
example: `https://twitter.com/foo/status/123456789?` to `https://twitter.com/foo/status/123456789`